### PR TITLE
Deserialize all fields.

### DIFF
--- a/jsonapi-deserializable.gemspec
+++ b/jsonapi-deserializable.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'lib/**/*']
   spec.require_path  = 'lib'
 
+  spec.add_dependency 'jsonapi-parser', '0.1.1.beta3'
+
   spec.add_development_dependency 'rake', '>=0.9'
   spec.add_development_dependency 'rspec', '~>3.4'
   spec.add_development_dependency 'codecov', '~> 0.1'

--- a/lib/jsonapi/deserializable/relationship.rb
+++ b/lib/jsonapi/deserializable/relationship.rb
@@ -34,14 +34,6 @@ module JSONAPI
 
       private
 
-      def deserialize_has_one(_rel, id, type)
-        { id: id, type: type }
-      end
-
-      def deserialize_has_many(_rel, ids, types)
-        { ids: ids, types: types }
-      end
-
       def deserialize!
         @hash =
           if @data.is_a?(Array)
@@ -57,7 +49,7 @@ module JSONAPI
         if self.class.has_one_block
           self.class.has_one_block.call(@document, id, type)
         else
-          deserialize_has_one(@document, id, type)
+          { id: id, type: type }
         end
       end
 
@@ -67,7 +59,7 @@ module JSONAPI
         if self.class.has_many_block
           self.class.has_many_block.call(@document, ids, types)
         else
-          deserialize_has_many(@document, ids, types)
+          { ids: ids, types: types }
         end
       end
     end

--- a/lib/jsonapi/deserializable/relationship.rb
+++ b/lib/jsonapi/deserializable/relationship.rb
@@ -1,4 +1,5 @@
 require 'jsonapi/deserializable/relationship_dsl'
+require 'jsonapi/parser/relationship'
 
 module JSONAPI
   module Deserializable
@@ -19,9 +20,11 @@ module JSONAPI
       end
 
       def initialize(payload)
+        Parser::Relationship.parse!(payload)
         @document = payload
         @data = payload['data']
-        _deserialize!
+        deserialize!
+        freeze
       end
 
       def to_hash
@@ -39,12 +42,7 @@ module JSONAPI
         { ids: ids, types: types }
       end
 
-      def _deserialize!
-        unless @document.key?('data')
-          @hash = {}
-          return
-        end
-
+      def deserialize!
         @hash =
           if @data.is_a?(Array)
             _deserialize_has_many

--- a/lib/jsonapi/deserializable/relationship_dsl.rb
+++ b/lib/jsonapi/deserializable/relationship_dsl.rb
@@ -7,12 +7,10 @@ module JSONAPI
 
       module ClassMethods
         def has_one(&block)
-          block ||= proc { |rel| field relationship: rel }
           self.has_one_block = block
         end
 
         def has_many(&block)
-          block ||= proc { |rel| field relationship: rel }
           self.has_many_block = block
         end
       end

--- a/lib/jsonapi/deserializable/resource.rb
+++ b/lib/jsonapi/deserializable/resource.rb
@@ -3,24 +3,46 @@ require 'jsonapi/deserializable/resource_dsl'
 module JSONAPI
   module Deserializable
     class Resource
+      DEFAULT_TYPE_BLOCK = proc { |t| field type: t }
+      DEFAULT_ID_BLOCK   = proc { |i| field id: i }
+      DEFAULT_ATTR_BLOCK = proc { |k, v| field(k.to_sym => v) }
+      DEFAULT_HAS_ONE_REL_BLOCK = proc do |k, _rel, id, type|
+        field "#{k}_type".to_sym => type
+        field "#{k}_id".to_sym   => id
+      end
+      DEFAULT_HAS_MANY_REL_BLOCK = proc do |k, _rel, ids, types|
+        field "#{k}_types".to_sym => types
+        field "#{k}_ids".to_sym   => ids
+      end
+
       include ResourceDSL
 
       class << self
-        attr_accessor :type_block, :id_block, :attr_blocks,
-                      :has_one_rel_blocks, :has_many_rel_blocks
+        attr_accessor :type_block, :id_block, :attr_blocks, :default_attr_block,
+                      :has_one_rel_blocks, :has_many_rel_blocks,
+                      :default_has_one_rel_block,
+                      :default_has_many_rel_block
       end
 
       self.attr_blocks = {}
       self.has_one_rel_blocks  = {}
       self.has_many_rel_blocks = {}
+      self.type_block = DEFAULT_TYPE_BLOCK
+      self.id_block   = DEFAULT_ID_BLOCK
+      self.default_attr_block         = DEFAULT_ATTR_BLOCK
+      self.default_has_one_rel_block  = DEFAULT_HAS_ONE_REL_BLOCK
+      self.default_has_many_rel_block = DEFAULT_HAS_MANY_REL_BLOCK
 
       def self.inherited(klass)
         super
         klass.type_block  = type_block
         klass.id_block    = id_block
-        klass.attr_blocks = attr_blocks.dup
+        klass.attr_blocks         = attr_blocks.dup
         klass.has_one_rel_blocks  = has_one_rel_blocks.dup
         klass.has_many_rel_blocks = has_many_rel_blocks.dup
+        klass.default_attr_block         = default_attr_block
+        klass.default_has_one_rel_block  = default_has_one_rel_block
+        klass.default_has_many_rel_block = default_has_many_rel_block
       end
 
       def self.call(payload)
@@ -53,53 +75,54 @@ module JSONAPI
       end
 
       def deserialize_type!
-        return unless @type && self.class.type_block
         instance_exec(@type, &self.class.type_block)
       end
 
       def deserialize_id!
-        return unless @id && self.class.id_block
+        return unless @id
         instance_exec(@id, &self.class.id_block)
       end
 
       def deserialize_attrs!
-        self.class.attr_blocks.each do |attr, block|
-          next unless @attributes.key?(attr)
-          instance_exec(@attributes[attr], &block)
+        @attributes.each do |key, val|
+          if self.class.attr_blocks.key?(key)
+            instance_exec(val, &self.class.attr_blocks[key])
+          else
+            instance_exec(key, val, &self.class.default_attr_block)
+          end
         end
       end
 
       def deserialize_rels!
-        deserialize_has_one_rels!
-        deserialize_has_many_rels!
-      end
-
-      def deserialize_has_one_rels!
-        self.class.has_one_rel_blocks.each do |key, block|
-          rel = @relationships[key]
-          next unless rel && (rel['data'].nil? || rel['data'].is_a?(Hash))
-          deserialize_has_one_rel!(rel, &block)
+        @relationships.each do |key, val|
+          if val['data'].is_a?(Array)
+            deserialize_has_many_rel!(key, val)
+          else
+            deserialize_has_one_rel!(key, val)
+          end
         end
       end
 
-      def deserialize_has_one_rel!(rel, &block)
-        id = rel['data'] && rel['data']['id']
-        type = rel['data'] && rel['data']['type']
-        instance_exec(rel, id, type, &block)
-      end
-
-      def deserialize_has_many_rels!
-        self.class.has_many_rel_blocks.each do |key, block|
-          rel = @relationships[key]
-          next unless rel && rel['data'].is_a?(Array)
-          deserialize_has_many_rel!(rel, &block)
+      def deserialize_has_one_rel!(key, val)
+        id   = val['data'] && val['data']['id']
+        type = val['data'] && val['data']['type']
+        if self.class.has_one_rel_blocks.key?(key)
+          instance_exec(val, id, type, &self.class.has_one_rel_blocks[key])
+        else
+          instance_exec(key, val, id, type,
+                        &self.class.default_has_one_rel_block)
         end
       end
 
-      def deserialize_has_many_rel!(rel, &block)
-        ids = rel['data'].map { |ri| ri['id'] }
-        types = rel['data'].map { |ri| ri['type'] }
-        instance_exec(rel, ids, types, &block)
+      def deserialize_has_many_rel!(key, val)
+        ids   = val['data'].map { |ri| ri['id'] }
+        types = val['data'].map { |ri| ri['type'] }
+        if self.class.has_many_rel_blocks.key?(key)
+          instance_exec(val, ids, types, &self.class.has_many_rel_blocks[key])
+        else
+          instance_exec(key, val, ids, types,
+                        &self.class.default_has_many_rel_block)
+        end
       end
 
       def field(hash)

--- a/lib/jsonapi/deserializable/resource.rb
+++ b/lib/jsonapi/deserializable/resource.rb
@@ -1,4 +1,5 @@
 require 'jsonapi/deserializable/resource_dsl'
+require 'jsonapi/parser/resource'
 
 module JSONAPI
   module Deserializable
@@ -28,6 +29,7 @@ module JSONAPI
       end
 
       def initialize(payload)
+        Parser::Resource.parse!(payload)
         @document = payload
         @data = @document['data']
         @type = @data['type']
@@ -35,6 +37,7 @@ module JSONAPI
         @attributes    = @data['attributes'] || {}
         @relationships = @data['relationships'] || {}
         deserialize!
+        freeze
       end
 
       def to_hash
@@ -117,9 +120,9 @@ module JSONAPI
         id   = val['data'] && val['data']['id']
         type = val['data'] && val['data']['type']
         if self.class.has_one_rel_blocks.key?(key)
-          @hash.merge!(self.class.has_one_rel_blocks[key].call(val, id, type))
+          self.class.has_one_rel_blocks[key].call(val, id, type)
         else
-          @hash.merge!(deserialize_has_one(key, val, id, type))
+          deserialize_has_one(key, val, id, type)
         end
       end
 

--- a/lib/jsonapi/deserializable/resource.rb
+++ b/lib/jsonapi/deserializable/resource.rb
@@ -3,33 +3,16 @@ require 'jsonapi/deserializable/resource_dsl'
 module JSONAPI
   module Deserializable
     class Resource
-      DEFAULT_TYPE_BLOCK = proc { |t| Hash[type: t] }
-      DEFAULT_ID_BLOCK   = proc { |i| Hash[id: i] }
-      DEFAULT_ATTR_BLOCK = proc { |k, v| Hash[k.to_sym => v] }
-      DEFAULT_HAS_ONE_REL_BLOCK = proc do |k, _rel, id, type|
-        Hash["#{k}_type".to_sym => type, "#{k}_id".to_sym => id]
-      end
-      DEFAULT_HAS_MANY_REL_BLOCK = proc do |k, _rel, ids, types|
-        Hash["#{k}_types".to_sym => types, "#{k}_ids".to_sym => ids]
-      end
-
       include ResourceDSL
 
       class << self
-        attr_accessor :type_block, :id_block, :attr_blocks, :default_attr_block,
-                      :has_one_rel_blocks, :has_many_rel_blocks,
-                      :default_has_one_rel_block,
-                      :default_has_many_rel_block
+        attr_accessor :type_block, :id_block, :attr_blocks,
+                      :has_one_rel_blocks, :has_many_rel_blocks
       end
 
       self.attr_blocks = {}
       self.has_one_rel_blocks  = {}
       self.has_many_rel_blocks = {}
-      self.type_block = DEFAULT_TYPE_BLOCK
-      self.id_block   = DEFAULT_ID_BLOCK
-      self.default_attr_block         = DEFAULT_ATTR_BLOCK
-      self.default_has_one_rel_block  = DEFAULT_HAS_ONE_REL_BLOCK
-      self.default_has_many_rel_block = DEFAULT_HAS_MANY_REL_BLOCK
 
       def self.inherited(klass)
         super
@@ -38,9 +21,6 @@ module JSONAPI
         klass.attr_blocks         = attr_blocks.dup
         klass.has_one_rel_blocks  = has_one_rel_blocks.dup
         klass.has_many_rel_blocks = has_many_rel_blocks.dup
-        klass.default_attr_block         = default_attr_block
-        klass.default_has_one_rel_block  = default_has_one_rel_block
-        klass.default_has_many_rel_block = default_has_many_rel_block
       end
 
       def self.call(payload)
@@ -64,69 +44,93 @@ module JSONAPI
 
       private
 
+      def deserialize_type(type)
+        { type: type }
+      end
+
+      def deserialize_id(id)
+        { id: id }
+      end
+
+      def deserialize_attribute(key, value)
+        { key.to_sym => value }
+      end
+
+      def deserialize_has_one(key, _value, id, type)
+        { "#{key}_type".to_sym => type, "#{key}_id".to_sym => id }
+      end
+
+      def deserialize_has_many(key, _value, ids, types)
+        { "#{key}_types".to_sym => types, "#{key}_ids".to_sym => ids }
+      end
+
       def deserialize!
         @hash = {}
-        deserialize_type!
-        deserialize_id!
-        deserialize_attrs!
-        deserialize_rels!
+        _deserialize_type!
+        _deserialize_id!
+        _deserialize_attrs!
+        _deserialize_rels!
       end
 
-      def deserialize_type!
-        @hash.merge!(self.class.type_block.call(@type))
+      def _deserialize_type!
+        @hash.merge!(
+          if self.class.type_block
+            self.class.type_block.call(@type)
+          else
+            deserialize_type(@type)
+          end
+        )
       end
 
-      def deserialize_id!
+      def _deserialize_id!
         return unless @id
-        @hash.merge!(self.class.id_block.call(@id))
+        @hash.merge!(
+          if self.class.id_block
+            self.class.id_block.call(@id)
+          else
+            deserialize_id(@id)
+          end
+        )
       end
 
-      def deserialize_attrs!
+      def _deserialize_attrs!
         @attributes.each do |key, val|
           if self.class.attr_blocks.key?(key)
             @hash.merge!(self.class.attr_blocks[key].call(val))
           else
-            @hash.merge!(self.class.default_attr_block.call(key, val))
+            @hash.merge!(deserialize_attribute(key, val))
           end
         end
       end
 
-      def deserialize_rels!
+      def _deserialize_rels!
         @relationships.each do |key, val|
           if val['data'].is_a?(Array)
-            deserialize_has_many_rel!(key, val)
+            @hash.merge!(_deserialize_has_many_rel(key, val))
           else
-            deserialize_has_one_rel!(key, val)
+            @hash.merge!(_deserialize_has_one_rel(key, val))
           end
         end
       end
 
-      def deserialize_has_one_rel!(key, val)
+      def _deserialize_has_one_rel(key, val)
         id   = val['data'] && val['data']['id']
         type = val['data'] && val['data']['type']
-        @hash.merge!(
-          if self.class.has_one_rel_blocks.key?(key)
-            self.class.has_one_rel_blocks[key].call(val, id, type)
-          else
-            self.class.default_has_one_rel_block.call(key, val, id, type)
-          end
-        )
+        if self.class.has_one_rel_blocks.key?(key)
+          @hash.merge!(self.class.has_one_rel_blocks[key].call(val, id, type))
+        else
+          @hash.merge!(deserialize_has_one(key, val, id, type))
+        end
       end
 
-      def deserialize_has_many_rel!(key, val)
+      def _deserialize_has_many_rel(key, val)
         ids   = val['data'].map { |ri| ri['id'] }
         types = val['data'].map { |ri| ri['type'] }
-        @hash.merge!(
-          if self.class.has_many_rel_blocks.key?(key)
-            self.class.has_many_rel_blocks[key].call(val, ids, types)
-          else
-            self.class.default_has_many_rel_block.call(key, val, ids, types)
-          end
-        )
-      end
-
-      def field(hash)
-        @hash.merge!(hash)
+        if self.class.has_many_rel_blocks.key?(key)
+          self.class.has_many_rel_blocks[key].call(val, ids, types)
+        else
+          deserialize_has_many(key, val, ids, types)
+        end
       end
     end
   end

--- a/lib/jsonapi/deserializable/resource_dsl.rb
+++ b/lib/jsonapi/deserializable/resource_dsl.rb
@@ -14,16 +14,28 @@ module JSONAPI
           self.id_block = block
         end
 
-        def attribute(key, &block)
-          attr_blocks[key.to_s] = block
+        def attribute(key = nil, &block)
+          if key.nil?
+            self.default_attr_block = block
+          else
+            attr_blocks[key.to_s] = block
+          end
         end
 
-        def has_one(key, &block)
-          has_one_rel_blocks[key.to_s] = block
+        def has_one(key = nil, &block)
+          if key.nil?
+            self.default_has_one_block = block
+          else
+            has_one_rel_blocks[key.to_s] = block
+          end
         end
 
-        def has_many(key, &block)
-          has_many_rel_blocks[key.to_s] = block
+        def has_many(key = nil, &block)
+          if key.nil?
+            self.default_has_many_block = block
+          else
+            has_many_rel_blocks[key.to_s] = block
+          end
         end
       end
     end

--- a/lib/jsonapi/deserializable/resource_dsl.rb
+++ b/lib/jsonapi/deserializable/resource_dsl.rb
@@ -23,11 +23,6 @@ module JSONAPI
           end
         end
 
-        def relationship(&block)
-          self.default_has_one_rel_block  = block
-          self.default_has_many_rel_block = block
-        end
-
         def has_one(key = nil, &block)
           if key.nil?
             self.default_has_one_rel_block = block

--- a/lib/jsonapi/deserializable/resource_dsl.rb
+++ b/lib/jsonapi/deserializable/resource_dsl.rb
@@ -7,7 +7,6 @@ module JSONAPI
 
       module ClassMethods
         def type(&block)
-          raise if block.nil?
           self.type_block = block
         end
 
@@ -15,28 +14,16 @@ module JSONAPI
           self.id_block = block
         end
 
-        def attribute(key = nil, &block)
-          if key.nil?
-            self.default_attr_block = block
-          else
-            attr_blocks[key.to_s] = block
-          end
+        def attribute(key, &block)
+          attr_blocks[key.to_s] = block
         end
 
-        def has_one(key = nil, &block)
-          if key.nil?
-            self.default_has_one_rel_block = block
-          else
-            has_one_rel_blocks[key.to_s] = block
-          end
+        def has_one(key, &block)
+          has_one_rel_blocks[key.to_s] = block
         end
 
-        def has_many(key = nil, &block)
-          if key.nil?
-            self.default_has_many_rel_block = block
-          else
-            has_many_rel_blocks[key.to_s] = block
-          end
+        def has_many(key, &block)
+          has_many_rel_blocks[key.to_s] = block
         end
       end
     end

--- a/lib/jsonapi/deserializable/resource_dsl.rb
+++ b/lib/jsonapi/deserializable/resource_dsl.rb
@@ -7,31 +7,41 @@ module JSONAPI
 
       module ClassMethods
         def type(&block)
-          block ||= proc { |type| field type: type }
+          raise if block.nil?
           self.type_block = block
         end
 
         def id(&block)
-          block ||= proc { |id| field id: id }
           self.id_block = block
         end
 
-        def attribute(key, options = {}, &block)
-          unless block
-            options[:key] ||= key.to_sym
-            block = proc { |attr| field key => attr }
+        def attribute(key = nil, &block)
+          if key.nil?
+            self.default_attr_block = block
+          else
+            attr_blocks[key.to_s] = block
           end
-          attr_blocks[key.to_s] = block
         end
 
-        def has_one(key, &block)
-          block ||= proc { |rel| field key.to_sym => rel }
-          has_one_rel_blocks[key.to_s] = block
+        def relationship(&block)
+          self.default_has_one_rel_block  = block
+          self.default_has_many_rel_block = block
         end
 
-        def has_many(key, &block)
-          block ||= proc { |rel| field key.to_sym => rel }
-          has_many_rel_blocks[key.to_s] = block
+        def has_one(key = nil, &block)
+          if key.nil?
+            self.default_has_one_rel_block = block
+          else
+            has_one_rel_blocks[key.to_s] = block
+          end
+        end
+
+        def has_many(key = nil, &block)
+          if key.nil?
+            self.default_has_many_rel_block = block
+          else
+            has_many_rel_blocks[key.to_s] = block
+          end
         end
       end
     end

--- a/spec/relationship/has_many_spec.rb
+++ b/spec/relationship/has_many_spec.rb
@@ -47,12 +47,10 @@ describe JSONAPI::Deserializable::Relationship, '.has_many' do
   end
 
   context 'data is absent' do
-    it 'does not create fields' do
+    it 'raises InvalidDocument' do
       payload = {}
-      actual = deserializable_foo.call(payload)
-      expected = {}
 
-      expect(actual).to eq(expected)
+      expect { deserializable_foo.call(payload) }.to raise_error
     end
   end
 

--- a/spec/relationship/has_many_spec.rb
+++ b/spec/relationship/has_many_spec.rb
@@ -50,7 +50,8 @@ describe JSONAPI::Deserializable::Relationship, '.has_many' do
     it 'raises InvalidDocument' do
       payload = {}
 
-      expect { deserializable_foo.call(payload) }.to raise_error
+      expect { deserializable_foo.call(payload) }
+        .to raise_error(JSONAPI::Parser::InvalidDocument)
     end
   end
 

--- a/spec/relationship/has_many_spec.rb
+++ b/spec/relationship/has_many_spec.rb
@@ -4,9 +4,7 @@ describe JSONAPI::Deserializable::Relationship, '.has_many' do
   let(:deserializable_foo) do
     Class.new(JSONAPI::Deserializable::Relationship) do
       has_many do |rel, ids, types|
-        field foo_ids: ids
-        field foo_types: types
-        field foo_rel: rel
+        { foo_ids: ids, foo_types: types, foo_rel: rel }
       end
     end
   end
@@ -29,12 +27,10 @@ describe JSONAPI::Deserializable::Relationship, '.has_many' do
       expect(actual).to eq(expected)
     end
 
-    it 'defaults to creating a relationship field' do
-      klass = Class.new(JSONAPI::Deserializable::Relationship) do
-        has_many
-      end
+    it 'defaults to creating ids and types fields' do
+      klass = Class.new(JSONAPI::Deserializable::Relationship)
       actual = klass.call(payload)
-      expected = { relationship: payload }
+      expected = { ids: %w(bar baz), types: %w(foo foo) }
 
       expect(actual).to eq(expected)
     end
@@ -51,7 +47,7 @@ describe JSONAPI::Deserializable::Relationship, '.has_many' do
   end
 
   context 'data is absent' do
-    it 'does not create corresponding fields' do
+    it 'does not create fields' do
       payload = {}
       actual = deserializable_foo.call(payload)
       expected = {}
@@ -61,10 +57,10 @@ describe JSONAPI::Deserializable::Relationship, '.has_many' do
   end
 
   context 'relationship is not to-many' do
-    it 'does not create corresponding fields' do
+    it 'falls back to default to-one deserialization scheme' do
       payload = { 'data' => nil }
       actual = deserializable_foo.call(payload)
-      expected = {}
+      expected = { id: nil, type: nil }
 
       expect(actual).to eq(expected)
     end

--- a/spec/relationship/has_one_spec.rb
+++ b/spec/relationship/has_one_spec.rb
@@ -41,12 +41,10 @@ describe JSONAPI::Deserializable::Relationship, '.has_one' do
   end
 
   context 'data is absent' do
-    it 'does not create corresponding fields' do
+    it 'raises InvalidDocument' do
       payload = {}
-      actual = deserializable_foo.call(payload)
-      expected = {}
 
-      expect(actual).to eq(expected)
+      expect { deserializable_foo.call(payload) }.to raise_error
     end
   end
 

--- a/spec/relationship/has_one_spec.rb
+++ b/spec/relationship/has_one_spec.rb
@@ -44,7 +44,8 @@ describe JSONAPI::Deserializable::Relationship, '.has_one' do
     it 'raises InvalidDocument' do
       payload = {}
 
-      expect { deserializable_foo.call(payload) }.to raise_error
+      expect { deserializable_foo.call(payload) }
+        .to raise_error(JSONAPI::Parser::InvalidDocument)
     end
   end
 

--- a/spec/relationship/has_one_spec.rb
+++ b/spec/relationship/has_one_spec.rb
@@ -4,9 +4,7 @@ describe JSONAPI::Deserializable::Relationship, '.has_one' do
   let(:deserializable_foo) do
     Class.new(JSONAPI::Deserializable::Relationship) do
       has_one do |rel, id, type|
-        field foo_id: id
-        field foo_type: type
-        field foo_rel: rel
+        { foo_id: id, foo_type: type, foo_rel: rel }
       end
     end
   end
@@ -23,12 +21,10 @@ describe JSONAPI::Deserializable::Relationship, '.has_one' do
       expect(actual).to eq(expected)
     end
 
-    it 'defaults to creating a relationship field' do
-      klass = Class.new(JSONAPI::Deserializable::Relationship) do
-        has_one
-      end
+    it 'defaults to creating id and type fields' do
+      klass = Class.new(JSONAPI::Deserializable::Relationship)
       actual = klass.call(payload)
-      expected = { relationship: payload }
+      expected = { id: 'bar', type: 'foo' }
 
       expect(actual).to eq(expected)
     end
@@ -55,10 +51,10 @@ describe JSONAPI::Deserializable::Relationship, '.has_one' do
   end
 
   context 'relationship is not to-one' do
-    it 'does not create corresponding fields' do
+    it 'falls back to default has_many deserialization scheme ' do
       payload = { 'data' => [] }
       actual = deserializable_foo.call(payload)
-      expected = {}
+      expected = { ids: [], types: [] }
 
       expect(actual).to eq(expected)
     end

--- a/spec/resource/DSL/attribute_spec.rb
+++ b/spec/resource/DSL/attribute_spec.rb
@@ -1,80 +1,76 @@
 require 'spec_helper'
 
 describe JSONAPI::Deserializable::Resource, '.attribute' do
-  context 'when providing the attribute name' do
-    it 'creates corresponding field if attribute is present' do
-      payload = {
-        'data' => {
-          'type' => 'foo',
-          'attributes' => { 'foo' => 'bar' }
-        }
+  it 'creates corresponding field if attribute is present' do
+    payload = {
+      'data' => {
+        'type' => 'foo',
+        'attributes' => { 'foo' => 'bar' }
       }
-      klass = Class.new(JSONAPI::Deserializable::Resource) do
-        attribute(:foo) { |foo| Hash[foo: foo] }
-      end
-      actual = klass.call(payload)
-      expected = { foo: 'bar', type: 'foo' }
-
-      expect(actual).to eq(expected)
+    }
+    klass = Class.new(JSONAPI::Deserializable::Resource) do
+      attribute(:foo) { |foo| Hash[foo: foo] }
     end
+    actual = klass.call(payload)
+    expected = { foo: 'bar', type: 'foo' }
 
-    it 'does not create corresponding field if attribute is absent' do
-      payload = { 'data' => { 'type' => 'foo' }, 'attributes' => {} }
-      klass = Class.new(JSONAPI::Deserializable::Resource) do
-        attribute(:foo) { |foo| Hash[foo: foo] }
-      end
-      actual = klass.call(payload)
-      expected = { type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-
-    it 'does not create corresponding field if no attribute specified' do
-      payload = { 'data' => { 'type' => 'foo' } }
-      klass = Class.new(JSONAPI::Deserializable::Resource) do
-        attribute(:foo) { |foo| Hash[foo: foo] }
-      end
-      actual = klass.call(payload)
-      expected = { type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-
-    it 'defaults to creating a field with same name' do
-      payload = {
-        'data' => {
-          'type' => 'foo',
-          'attributes' => { 'foo' => 'bar' }
-        }
-      }
-      klass = Class.new(JSONAPI::Deserializable::Resource)
-      actual = klass.call(payload)
-      expected = { foo: 'bar', type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
+    expect(actual).to eq(expected)
   end
 
-  context 'when omitting the attribute name' do
-    it 'sets the default attribute deserialization scheme' do
-      payload = {
-        'data' => {
-          'type' => 'foo',
-          'attributes' => {
-            'foo' => 'bar',
-            'baz' => 'foo'
-          }
+  it 'does not create corresponding field if attribute is absent' do
+    payload = { 'data' => { 'type' => 'foo' }, 'attributes' => {} }
+    klass = Class.new(JSONAPI::Deserializable::Resource) do
+      attribute(:foo) { |foo| Hash[foo: foo] }
+    end
+    actual = klass.call(payload)
+    expected = { type: 'foo' }
+
+    expect(actual).to eq(expected)
+  end
+
+  it 'does not create corresponding field if no attribute specified' do
+    payload = { 'data' => { 'type' => 'foo' } }
+    klass = Class.new(JSONAPI::Deserializable::Resource) do
+      attribute(:foo) { |foo| Hash[foo: foo] }
+    end
+    actual = klass.call(payload)
+    expected = { type: 'foo' }
+
+    expect(actual).to eq(expected)
+  end
+
+  it 'defaults to creating a field with same name' do
+    payload = {
+      'data' => {
+        'type' => 'foo',
+        'attributes' => { 'foo' => 'bar' }
+      }
+    }
+    klass = Class.new(JSONAPI::Deserializable::Resource)
+    actual = klass.call(payload)
+    expected = { foo: 'bar', type: 'foo' }
+
+    expect(actual).to eq(expected)
+  end
+
+  it 'overrides default attribute deserialization scheme' do
+    payload = {
+      'data' => {
+        'type' => 'foo',
+        'attributes' => {
+          'foo' => 'bar',
+          'baz' => 'foo'
         }
       }
-      klass = Class.new(JSONAPI::Deserializable::Resource) do
-        attribute do |name, value|
-          Hash["custom_#{name}".to_sym => value]
-        end
+    }
+    klass = Class.new(JSONAPI::Deserializable::Resource) do
+      def deserialize_attribute(name, value)
+        { "custom_#{name}".to_sym => value }
       end
-      actual = klass.call(payload)
-      expected = { custom_foo: 'bar', custom_baz: 'foo', type: 'foo' }
-
-      expect(actual).to eq(expected)
     end
+    actual = klass.call(payload)
+    expected = { custom_foo: 'bar', custom_baz: 'foo', type: 'foo' }
+
+    expect(actual).to eq(expected)
   end
 end

--- a/spec/resource/DSL/attribute_spec.rb
+++ b/spec/resource/DSL/attribute_spec.rb
@@ -1,55 +1,80 @@
 require 'spec_helper'
 
 describe JSONAPI::Deserializable::Resource, '.attribute' do
-  it 'creates corresponding field if attribute is present' do
-    payload = {
-      'data' => {
-        'type' => 'foo',
-        'attributes' => { 'foo' => 'bar' }
+  context 'when providing the attribute name' do
+    it 'creates corresponding field if attribute is present' do
+      payload = {
+        'data' => {
+          'type' => 'foo',
+          'attributes' => { 'foo' => 'bar' }
+        }
       }
-    }
-    klass = Class.new(JSONAPI::Deserializable::Resource) do
-      attribute(:foo) { |foo| field foo: foo }
+      klass = Class.new(JSONAPI::Deserializable::Resource) do
+        attribute(:foo) { |foo| field foo: foo }
+      end
+      actual = klass.call(payload)
+      expected = { foo: 'bar', type: 'foo' }
+
+      expect(actual).to eq(expected)
     end
-    actual = klass.call(payload)
-    expected = { foo: 'bar', type: 'foo' }
 
-    expect(actual).to eq(expected)
-  end
+    it 'does not create corresponding field if attribute is absent' do
+      payload = { 'data' => { 'type' => 'foo' }, 'attributes' => {} }
+      klass = Class.new(JSONAPI::Deserializable::Resource) do
+        attribute(:foo) { |foo| field foo: foo }
+      end
+      actual = klass.call(payload)
+      expected = { type: 'foo' }
 
-  it 'does not create corresponding field if attribute is absent' do
-    payload = { 'data' => { 'type' => 'foo' }, 'attributes' => {} }
-    klass = Class.new(JSONAPI::Deserializable::Resource) do
-      attribute(:foo) { |foo| field foo: foo }
+      expect(actual).to eq(expected)
     end
-    actual = klass.call(payload)
-    expected = { type: 'foo' }
 
-    expect(actual).to eq(expected)
-  end
+    it 'does not create corresponding field if no attribute specified' do
+      payload = { 'data' => { 'type' => 'foo' } }
+      klass = Class.new(JSONAPI::Deserializable::Resource) do
+        attribute(:foo) { |foo| field foo: foo }
+      end
+      actual = klass.call(payload)
+      expected = { type: 'foo' }
 
-  it 'does not create corresponding field if no attribute specified' do
-    payload = { 'data' => { 'type' => 'foo' } }
-    klass = Class.new(JSONAPI::Deserializable::Resource) do
-      attribute(:foo) { |foo| field foo: foo }
+      expect(actual).to eq(expected)
     end
-    actual = klass.call(payload)
-    expected = { type: 'foo' }
 
-    expect(actual).to eq(expected)
-  end
-
-  it 'defaults to creating a field with same name' do
-    payload = {
-      'data' => {
-        'type' => 'foo',
-        'attributes' => { 'foo' => 'bar' }
+    it 'defaults to creating a field with same name' do
+      payload = {
+        'data' => {
+          'type' => 'foo',
+          'attributes' => { 'foo' => 'bar' }
+        }
       }
-    }
-    klass = Class.new(JSONAPI::Deserializable::Resource)
-    actual = klass.call(payload)
-    expected = { foo: 'bar', type: 'foo' }
+      klass = Class.new(JSONAPI::Deserializable::Resource)
+      actual = klass.call(payload)
+      expected = { foo: 'bar', type: 'foo' }
 
-    expect(actual).to eq(expected)
+      expect(actual).to eq(expected)
+    end
+  end
+
+  context 'when omitting the attribute name' do
+    it 'sets the default attribute deserialization scheme' do
+      payload = {
+        'data' => {
+          'type' => 'foo',
+          'attributes' => {
+            'foo' => 'bar',
+            'baz' => 'foo'
+          }
+        }
+      }
+      klass = Class.new(JSONAPI::Deserializable::Resource) do
+        attribute do |name, value|
+          field "custom_#{name}".to_sym => value
+        end
+      end
+      actual = klass.call(payload)
+      expected = { custom_foo: 'bar', custom_baz: 'foo', type: 'foo' }
+
+      expect(actual).to eq(expected)
+    end
   end
 end

--- a/spec/resource/DSL/attribute_spec.rb
+++ b/spec/resource/DSL/attribute_spec.rb
@@ -10,7 +10,7 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
         }
       }
       klass = Class.new(JSONAPI::Deserializable::Resource) do
-        attribute(:foo) { |foo| field foo: foo }
+        attribute(:foo) { |foo| Hash[foo: foo] }
       end
       actual = klass.call(payload)
       expected = { foo: 'bar', type: 'foo' }
@@ -21,7 +21,7 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
     it 'does not create corresponding field if attribute is absent' do
       payload = { 'data' => { 'type' => 'foo' }, 'attributes' => {} }
       klass = Class.new(JSONAPI::Deserializable::Resource) do
-        attribute(:foo) { |foo| field foo: foo }
+        attribute(:foo) { |foo| Hash[foo: foo] }
       end
       actual = klass.call(payload)
       expected = { type: 'foo' }
@@ -32,7 +32,7 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
     it 'does not create corresponding field if no attribute specified' do
       payload = { 'data' => { 'type' => 'foo' } }
       klass = Class.new(JSONAPI::Deserializable::Resource) do
-        attribute(:foo) { |foo| field foo: foo }
+        attribute(:foo) { |foo| Hash[foo: foo] }
       end
       actual = klass.call(payload)
       expected = { type: 'foo' }
@@ -68,7 +68,7 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
       }
       klass = Class.new(JSONAPI::Deserializable::Resource) do
         attribute do |name, value|
-          field "custom_#{name}".to_sym => value
+          Hash["custom_#{name}".to_sym => value]
         end
       end
       actual = klass.call(payload)

--- a/spec/resource/DSL/attribute_spec.rb
+++ b/spec/resource/DSL/attribute_spec.rb
@@ -18,7 +18,7 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
   end
 
   it 'does not create corresponding field if attribute is absent' do
-    payload = { 'data' => { 'type' => 'foo' }, 'attributes' => {} }
+    payload = { 'data' => { 'type' => 'foo', 'attributes' => {} } }
     klass = Class.new(JSONAPI::Deserializable::Resource) do
       attribute(:foo) { |foo| Hash[foo: foo] }
     end

--- a/spec/resource/DSL/attribute_spec.rb
+++ b/spec/resource/DSL/attribute_spec.rb
@@ -64,7 +64,7 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
       }
     }
     klass = Class.new(JSONAPI::Deserializable::Resource) do
-      def deserialize_attribute(name, value)
+      attribute do |name, value|
         { "custom_#{name}".to_sym => value }
       end
     end

--- a/spec/resource/DSL/attribute_spec.rb
+++ b/spec/resource/DSL/attribute_spec.rb
@@ -12,7 +12,7 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
       attribute(:foo) { |foo| field foo: foo }
     end
     actual = klass.call(payload)
-    expected = { foo: 'bar' }
+    expected = { foo: 'bar', type: 'foo' }
 
     expect(actual).to eq(expected)
   end
@@ -23,7 +23,7 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
       attribute(:foo) { |foo| field foo: foo }
     end
     actual = klass.call(payload)
-    expected = {}
+    expected = { type: 'foo' }
 
     expect(actual).to eq(expected)
   end
@@ -34,7 +34,7 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
       attribute(:foo) { |foo| field foo: foo }
     end
     actual = klass.call(payload)
-    expected = {}
+    expected = { type: 'foo' }
 
     expect(actual).to eq(expected)
   end
@@ -46,11 +46,9 @@ describe JSONAPI::Deserializable::Resource, '.attribute' do
         'attributes' => { 'foo' => 'bar' }
       }
     }
-    klass = Class.new(JSONAPI::Deserializable::Resource) do
-      attribute :foo
-    end
+    klass = Class.new(JSONAPI::Deserializable::Resource)
     actual = klass.call(payload)
-    expected = { foo: 'bar' }
+    expected = { foo: 'bar', type: 'foo' }
 
     expect(actual).to eq(expected)
   end

--- a/spec/resource/DSL/has_many_spec.rb
+++ b/spec/resource/DSL/has_many_spec.rb
@@ -111,7 +111,7 @@ describe JSONAPI::Deserializable::Resource, '.has_many' do
       }
     }
     klass = Class.new(JSONAPI::Deserializable::Resource) do
-      def deserialize_has_many(name, _value, ids, types)
+      has_many do |name, _value, ids, types|
         { "custom_#{name}_ids".to_sym => ids,
           "custom_#{name}_types".to_sym => types }
       end

--- a/spec/resource/DSL/has_many_spec.rb
+++ b/spec/resource/DSL/has_many_spec.rb
@@ -4,9 +4,7 @@ describe JSONAPI::Deserializable::Resource, '.has_many' do
   let(:deserializable_foo) do
     Class.new(JSONAPI::Deserializable::Resource) do
       has_many :foo do |rel, ids, types|
-        field foo_ids: ids
-        field foo_types: types
-        field foo_rel: rel
+        Hash[foo_ids: ids, foo_types: types, foo_rel: rel]
       end
     end
   end
@@ -117,8 +115,8 @@ describe JSONAPI::Deserializable::Resource, '.has_many' do
       }
       klass = Class.new(JSONAPI::Deserializable::Resource) do
         has_many do |name, _value, ids, types|
-          field "custom_#{name}_ids".to_sym => ids
-          field "custom_#{name}_types".to_sym => types
+          Hash["custom_#{name}_ids".to_sym => ids,
+               "custom_#{name}_types".to_sym => types]
         end
       end
       actual = klass.call(payload)

--- a/spec/resource/DSL/has_many_spec.rb
+++ b/spec/resource/DSL/has_many_spec.rb
@@ -11,86 +11,120 @@ describe JSONAPI::Deserializable::Resource, '.has_many' do
     end
   end
 
-  context 'relationship is not empty' do
-    let(:payload) do
-      {
+  context 'when providing the relationship name' do
+    context 'relationship is not empty' do
+      let(:payload) do
+        {
+          'data' => {
+            'type' => 'foo',
+            'relationships' => {
+              'foo' => {
+                'data' => [
+                  { 'type' => 'foo', 'id' => 'bar' },
+                  { 'type' => 'foo', 'id' => 'baz' }
+                ]
+              }
+            }
+          }
+        }
+      end
+
+      it 'creates corresponding fields' do
+        actual = deserializable_foo.call(payload)
+        expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo),
+                     foo_rel: payload['data']['relationships']['foo'],
+                     type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+
+      it 'defaults to creating a #{name}_ids and #{name}_types fields' do
+        klass = Class.new(JSONAPI::Deserializable::Resource)
+        actual = klass.call(payload)
+        expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo), type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'relationship is empty' do
+      it 'creates corresponding fields' do
+        payload = {
+          'data' => {
+            'type' => 'foo',
+            'relationships' => {
+              'foo' => {
+                'data' => []
+              }
+            }
+          }
+        }
+        actual = deserializable_foo.call(payload)
+        expected = { foo_ids: [], foo_types: [],
+                     foo_rel: payload['data']['relationships']['foo'],
+                     type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'relationship is absent' do
+      it 'does not create corresponding fields' do
+        payload = {
+          'data' => {
+            'type' => 'foo',
+            'relationships' => {}
+          }
+        }
+        actual = deserializable_foo.call(payload)
+        expected = { type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'there is no relationships member' do
+      it 'does not create corresponding fields' do
+        payload = {
+          'data' => {
+            'type' => 'foo'
+          }
+        }
+        actual = deserializable_foo.call(payload)
+        expected = { type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+    end
+  end
+
+  context 'when omitting the relationship name' do
+    it 'sets the default has_many relationship deserialization scheme' do
+      payload = {
         'data' => {
           'type' => 'foo',
           'relationships' => {
             'foo' => {
-              'data' => [
-                { 'type' => 'foo', 'id' => 'bar' },
-                { 'type' => 'foo', 'id' => 'baz' }
-              ]
+              'data' => [{ 'type' => 'bar', 'id' => 'baz' },
+                         { 'type' => 'foo', 'id' => 'bar' }]
+            },
+            'bar' => {
+              'data' => [{ 'type' => 'baz', 'id' => 'foo' },
+                         { 'type' => 'baz', 'id' => 'buz' }]
             }
           }
         }
       }
-    end
-
-    it 'creates corresponding fields' do
-      actual = deserializable_foo.call(payload)
-      expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo),
-                   foo_rel: payload['data']['relationships']['foo'],
-                   type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-
-    it 'defaults to creating a #{name}_ids and #{name}_types fields' do
-      klass = Class.new(JSONAPI::Deserializable::Resource)
+      klass = Class.new(JSONAPI::Deserializable::Resource) do
+        has_many do |name, _value, ids, types|
+          field "custom_#{name}_ids".to_sym => ids
+          field "custom_#{name}_types".to_sym => types
+        end
+      end
       actual = klass.call(payload)
-      expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo), type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-  end
-
-  context 'relationship is empty' do
-    it 'creates corresponding fields' do
-      payload = {
-        'data' => {
-          'type' => 'foo',
-          'relationships' => {
-            'foo' => {
-              'data' => []
-            }
-          }
-        }
-      }
-      actual = deserializable_foo.call(payload)
-      expected = { foo_ids: [], foo_types: [],
-                   foo_rel: payload['data']['relationships']['foo'],
+      expected = { custom_foo_ids: %w(baz bar), custom_foo_types: %w(bar foo),
+                   custom_bar_ids: %w(foo buz), custom_bar_types: %w(baz baz),
                    type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-  end
-
-  context 'relationship is absent' do
-    it 'does not create corresponding fields' do
-      payload = {
-        'data' => {
-          'type' => 'foo',
-          'relationships' => {}
-        }
-      }
-      actual = deserializable_foo.call(payload)
-      expected = { type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-  end
-
-  context 'there is no relationships member' do
-    it 'does not create corresponding fields' do
-      payload = {
-        'data' => {
-          'type' => 'foo'
-        }
-      }
-      actual = deserializable_foo.call(payload)
-      expected = { type: 'foo' }
 
       expect(actual).to eq(expected)
     end

--- a/spec/resource/DSL/has_many_spec.rb
+++ b/spec/resource/DSL/has_many_spec.rb
@@ -31,17 +31,16 @@ describe JSONAPI::Deserializable::Resource, '.has_many' do
     it 'creates corresponding fields' do
       actual = deserializable_foo.call(payload)
       expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo),
-                   foo_rel: payload['data']['relationships']['foo'] }
+                   foo_rel: payload['data']['relationships']['foo'],
+                   type: 'foo' }
 
       expect(actual).to eq(expected)
     end
 
-    it 'defaults to creating a field of the same name' do
-      klass = Class.new(JSONAPI::Deserializable::Resource) do
-        has_many :foo
-      end
+    it 'defaults to creating a #{name}_ids and #{name}_types fields' do
+      klass = Class.new(JSONAPI::Deserializable::Resource)
       actual = klass.call(payload)
-      expected = { foo: payload['data']['relationships']['foo'] }
+      expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo), type: 'foo' }
 
       expect(actual).to eq(expected)
     end
@@ -61,7 +60,8 @@ describe JSONAPI::Deserializable::Resource, '.has_many' do
       }
       actual = deserializable_foo.call(payload)
       expected = { foo_ids: [], foo_types: [],
-                   foo_rel: payload['data']['relationships']['foo'] }
+                   foo_rel: payload['data']['relationships']['foo'],
+                   type: 'foo' }
 
       expect(actual).to eq(expected)
     end
@@ -76,7 +76,7 @@ describe JSONAPI::Deserializable::Resource, '.has_many' do
         }
       }
       actual = deserializable_foo.call(payload)
-      expected = {}
+      expected = { type: 'foo' }
 
       expect(actual).to eq(expected)
     end
@@ -90,27 +90,7 @@ describe JSONAPI::Deserializable::Resource, '.has_many' do
         }
       }
       actual = deserializable_foo.call(payload)
-      expected = {}
-
-      expect(actual).to eq(expected)
-    end
-  end
-
-  context 'relationship is not to-many' do
-    it 'does not create corresponding fields' do
-      payload = {
-        'data' => {
-          'type' => 'foo',
-          'relationships' => {
-            'foo' => {
-              'data' => { 'type' => 'foo', 'id' => 'bar' }
-            }
-          }
-        }
-      }
-
-      actual = deserializable_foo.call(payload)
-      expected = {}
+      expected = { type: 'foo' }
 
       expect(actual).to eq(expected)
     end

--- a/spec/resource/DSL/has_many_spec.rb
+++ b/spec/resource/DSL/has_many_spec.rb
@@ -9,122 +9,118 @@ describe JSONAPI::Deserializable::Resource, '.has_many' do
     end
   end
 
-  context 'when providing the relationship name' do
-    context 'relationship is not empty' do
-      let(:payload) do
-        {
-          'data' => {
-            'type' => 'foo',
-            'relationships' => {
-              'foo' => {
-                'data' => [
-                  { 'type' => 'foo', 'id' => 'bar' },
-                  { 'type' => 'foo', 'id' => 'baz' }
-                ]
-              }
+  context 'relationship is not empty' do
+    let(:payload) do
+      {
+        'data' => {
+          'type' => 'foo',
+          'relationships' => {
+            'foo' => {
+              'data' => [
+                { 'type' => 'foo', 'id' => 'bar' },
+                { 'type' => 'foo', 'id' => 'baz' }
+              ]
             }
           }
         }
-      end
-
-      it 'creates corresponding fields' do
-        actual = deserializable_foo.call(payload)
-        expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo),
-                     foo_rel: payload['data']['relationships']['foo'],
-                     type: 'foo' }
-
-        expect(actual).to eq(expected)
-      end
-
-      it 'defaults to creating a #{name}_ids and #{name}_types fields' do
-        klass = Class.new(JSONAPI::Deserializable::Resource)
-        actual = klass.call(payload)
-        expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo), type: 'foo' }
-
-        expect(actual).to eq(expected)
-      end
+      }
     end
 
-    context 'relationship is empty' do
-      it 'creates corresponding fields' do
-        payload = {
-          'data' => {
-            'type' => 'foo',
-            'relationships' => {
-              'foo' => {
-                'data' => []
-              }
-            }
-          }
-        }
-        actual = deserializable_foo.call(payload)
-        expected = { foo_ids: [], foo_types: [],
-                     foo_rel: payload['data']['relationships']['foo'],
-                     type: 'foo' }
+    it 'creates corresponding fields' do
+      actual = deserializable_foo.call(payload)
+      expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo),
+                   foo_rel: payload['data']['relationships']['foo'],
+                   type: 'foo' }
 
-        expect(actual).to eq(expected)
-      end
+      expect(actual).to eq(expected)
     end
 
-    context 'relationship is absent' do
-      it 'does not create corresponding fields' do
-        payload = {
-          'data' => {
-            'type' => 'foo',
-            'relationships' => {}
-          }
-        }
-        actual = deserializable_foo.call(payload)
-        expected = { type: 'foo' }
+    it 'defaults to creating a #{name}_ids and #{name}_types fields' do
+      klass = Class.new(JSONAPI::Deserializable::Resource)
+      actual = klass.call(payload)
+      expected = { foo_ids: %w(bar baz), foo_types: %w(foo foo), type: 'foo' }
 
-        expect(actual).to eq(expected)
-      end
-    end
-
-    context 'there is no relationships member' do
-      it 'does not create corresponding fields' do
-        payload = {
-          'data' => {
-            'type' => 'foo'
-          }
-        }
-        actual = deserializable_foo.call(payload)
-        expected = { type: 'foo' }
-
-        expect(actual).to eq(expected)
-      end
+      expect(actual).to eq(expected)
     end
   end
 
-  context 'when omitting the relationship name' do
-    it 'sets the default has_many relationship deserialization scheme' do
+  context 'relationship is empty' do
+    it 'creates corresponding fields' do
       payload = {
         'data' => {
           'type' => 'foo',
           'relationships' => {
             'foo' => {
-              'data' => [{ 'type' => 'bar', 'id' => 'baz' },
-                         { 'type' => 'foo', 'id' => 'bar' }]
-            },
-            'bar' => {
-              'data' => [{ 'type' => 'baz', 'id' => 'foo' },
-                         { 'type' => 'baz', 'id' => 'buz' }]
+              'data' => []
             }
           }
         }
       }
-      klass = Class.new(JSONAPI::Deserializable::Resource) do
-        has_many do |name, _value, ids, types|
-          Hash["custom_#{name}_ids".to_sym => ids,
-               "custom_#{name}_types".to_sym => types]
-        end
-      end
-      actual = klass.call(payload)
-      expected = { custom_foo_ids: %w(baz bar), custom_foo_types: %w(bar foo),
-                   custom_bar_ids: %w(foo buz), custom_bar_types: %w(baz baz),
+      actual = deserializable_foo.call(payload)
+      expected = { foo_ids: [], foo_types: [],
+                   foo_rel: payload['data']['relationships']['foo'],
                    type: 'foo' }
 
       expect(actual).to eq(expected)
     end
+  end
+
+  context 'relationship is absent' do
+    it 'does not create corresponding fields' do
+      payload = {
+        'data' => {
+          'type' => 'foo',
+          'relationships' => {}
+        }
+      }
+      actual = deserializable_foo.call(payload)
+      expected = { type: 'foo' }
+
+      expect(actual).to eq(expected)
+    end
+  end
+
+  context 'there is no relationships member' do
+    it 'does not create corresponding fields' do
+      payload = {
+        'data' => {
+          'type' => 'foo'
+        }
+      }
+      actual = deserializable_foo.call(payload)
+      expected = { type: 'foo' }
+
+      expect(actual).to eq(expected)
+    end
+  end
+
+  it 'overrides the default has_many relationship deserialization scheme' do
+    payload = {
+      'data' => {
+        'type' => 'foo',
+        'relationships' => {
+          'foo' => {
+            'data' => [{ 'type' => 'bar', 'id' => 'baz' },
+                       { 'type' => 'foo', 'id' => 'bar' }]
+          },
+          'bar' => {
+            'data' => [{ 'type' => 'baz', 'id' => 'foo' },
+                       { 'type' => 'baz', 'id' => 'buz' }]
+          }
+        }
+      }
+    }
+    klass = Class.new(JSONAPI::Deserializable::Resource) do
+      def deserialize_has_many(name, _value, ids, types)
+        { "custom_#{name}_ids".to_sym => ids,
+          "custom_#{name}_types".to_sym => types }
+      end
+    end
+    actual = klass.call(payload)
+    expected = { custom_foo_ids: %w(baz bar), custom_foo_types: %w(bar foo),
+                 custom_bar_ids: %w(foo buz), custom_bar_types: %w(baz baz),
+                 type: 'foo' }
+
+    expect(actual).to eq(expected)
   end
 end

--- a/spec/resource/DSL/has_one_spec.rb
+++ b/spec/resource/DSL/has_one_spec.rb
@@ -41,7 +41,7 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
     end
   end
 
-  context 'relationship is nil' do
+  context 'relationship value is nil' do
     it 'creates corresponding fields' do
       payload = {
         'data' => {
@@ -53,6 +53,7 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
           }
         }
       }
+
       actual = deserializable_foo.call(payload)
       expected = { foo_id: nil, foo_type: nil,
                    foo_rel: payload['data']['relationships']['foo'],

--- a/spec/resource/DSL/has_one_spec.rb
+++ b/spec/resource/DSL/has_one_spec.rb
@@ -9,113 +9,109 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
     end
   end
 
-  context 'when providing the relationship name' do
-    context 'relationship is not nil' do
-      let(:payload) do
-        {
-          'data' => {
-            'type' => 'foo',
-            'relationships' => {
-              'foo' => {
-                'data' => { 'type' => 'foo', 'id' => 'bar' }
-              }
-            }
-          }
-        }
-      end
-
-      it 'creates corresponding fields' do
-        actual = deserializable_foo.call(payload)
-        expected = { foo_id: 'bar', foo_type: 'foo',
-                     foo_rel: payload['data']['relationships']['foo'],
-                     type: 'foo' }
-
-        expect(actual).to eq(expected)
-      end
-
-      it 'defaults to creating #{name}_id and #{name}_type' do
-        klass = Class.new(JSONAPI::Deserializable::Resource)
-        actual = klass.call(payload)
-        expected = { foo_id: 'bar', foo_type: 'foo', type: 'foo' }
-
-        expect(actual).to eq(expected)
-      end
-    end
-
-    context 'relationship is nil' do
-      it 'creates corresponding fields' do
-        payload = {
-          'data' => {
-            'type' => 'foo',
-            'relationships' => {
-              'foo' => {
-                'data' => nil
-              }
-            }
-          }
-        }
-        actual = deserializable_foo.call(payload)
-        expected = { foo_id: nil, foo_type: nil,
-                     foo_rel: payload['data']['relationships']['foo'],
-                     type: 'foo' }
-
-        expect(actual).to eq(expected)
-      end
-    end
-
-    context 'relationship is absent' do
-      it 'does not create corresponding fields' do
-        payload = {
-          'data' => {
-            'type' => 'foo',
-            'relationships' => {}
-          }
-        }
-        actual = deserializable_foo.call(payload)
-        expected = { type: 'foo' }
-
-        expect(actual).to eq(expected)
-      end
-    end
-
-    context 'there is no relationships member' do
-      it 'does not create corresponding fields' do
-        payload = {
-          'data' => {
-            'type' => 'foo'
-          }
-        }
-        actual = deserializable_foo.call(payload)
-        expected = { type: 'foo' }
-
-        expect(actual).to eq(expected)
-      end
-    end
-  end
-
-  context 'when omitting the relationship name' do
-    it 'sets the default has_one relationship deserialization scheme' do
-      payload = {
+  context 'relationship is not nil' do
+    let(:payload) do
+      {
         'data' => {
           'type' => 'foo',
           'relationships' => {
-            'foo' => { 'data' => { 'type' => 'bar', 'id' => 'baz' } },
-            'bar' => { 'data' => { 'type' => 'foo', 'id' => 'bar' } }
+            'foo' => {
+              'data' => { 'type' => 'foo', 'id' => 'bar' }
+            }
           }
         }
       }
-      klass = Class.new(JSONAPI::Deserializable::Resource) do
-        has_one do |name, _value, id, type|
-          Hash["custom_#{name}_id".to_sym => id,
-               "custom_#{name}_type".to_sym => type]
-        end
-      end
-      actual = klass.call(payload)
-      expected = { custom_foo_id: 'baz', custom_foo_type: 'bar',
-                   custom_bar_id: 'bar', custom_bar_type: 'foo',
+    end
+
+    it 'creates corresponding fields' do
+      actual = deserializable_foo.call(payload)
+      expected = { foo_id: 'bar', foo_type: 'foo',
+                   foo_rel: payload['data']['relationships']['foo'],
                    type: 'foo' }
 
       expect(actual).to eq(expected)
     end
+
+    it 'defaults to creating #{name}_id and #{name}_type' do
+      klass = Class.new(JSONAPI::Deserializable::Resource)
+      actual = klass.call(payload)
+      expected = { foo_id: 'bar', foo_type: 'foo', type: 'foo' }
+
+      expect(actual).to eq(expected)
+    end
+  end
+
+  context 'relationship is nil' do
+    it 'creates corresponding fields' do
+      payload = {
+        'data' => {
+          'type' => 'foo',
+          'relationships' => {
+            'foo' => {
+              'data' => nil
+            }
+          }
+        }
+      }
+      actual = deserializable_foo.call(payload)
+      expected = { foo_id: nil, foo_type: nil,
+                   foo_rel: payload['data']['relationships']['foo'],
+                   type: 'foo' }
+
+      expect(actual).to eq(expected)
+    end
+  end
+
+  context 'relationship is absent' do
+    it 'does not create corresponding fields' do
+      payload = {
+        'data' => {
+          'type' => 'foo',
+          'relationships' => {}
+        }
+      }
+      actual = deserializable_foo.call(payload)
+      expected = { type: 'foo' }
+
+      expect(actual).to eq(expected)
+    end
+  end
+
+  context 'there is no relationships member' do
+    it 'does not create corresponding fields' do
+      payload = {
+        'data' => {
+          'type' => 'foo'
+        }
+      }
+      actual = deserializable_foo.call(payload)
+      expected = { type: 'foo' }
+
+      expect(actual).to eq(expected)
+    end
+  end
+
+  it 'overrides the default has_one relationship deserialization scheme' do
+    payload = {
+      'data' => {
+        'type' => 'foo',
+        'relationships' => {
+          'foo' => { 'data' => { 'type' => 'bar', 'id' => 'baz' } },
+          'bar' => { 'data' => { 'type' => 'foo', 'id' => 'bar' } }
+        }
+      }
+    }
+    klass = Class.new(JSONAPI::Deserializable::Resource) do
+      def deserialize_has_one(name, _value, id, type)
+        { "custom_#{name}_id".to_sym => id,
+          "custom_#{name}_type".to_sym => type }
+      end
+    end
+    actual = klass.call(payload)
+    expected = { custom_foo_id: 'baz', custom_foo_type: 'bar',
+                 custom_bar_id: 'bar', custom_bar_type: 'foo',
+                 type: 'foo' }
+
+    expect(actual).to eq(expected)
   end
 end

--- a/spec/resource/DSL/has_one_spec.rb
+++ b/spec/resource/DSL/has_one_spec.rb
@@ -28,17 +28,16 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
     it 'creates corresponding fields' do
       actual = deserializable_foo.call(payload)
       expected = { foo_id: 'bar', foo_type: 'foo',
-                   foo_rel: payload['data']['relationships']['foo'] }
+                   foo_rel: payload['data']['relationships']['foo'],
+                   type: 'foo' }
 
       expect(actual).to eq(expected)
     end
 
-    it 'defaults to creating a field of the same name' do
-      klass = Class.new(JSONAPI::Deserializable::Resource) do
-        has_one :foo
-      end
+    it 'defaults to creating #{name}_id and #{name}_type' do
+      klass = Class.new(JSONAPI::Deserializable::Resource)
       actual = klass.call(payload)
-      expected = { foo: payload['data']['relationships']['foo'] }
+      expected = { foo_id: 'bar', foo_type: 'foo', type: 'foo' }
 
       expect(actual).to eq(expected)
     end
@@ -58,7 +57,8 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
       }
       actual = deserializable_foo.call(payload)
       expected = { foo_id: nil, foo_type: nil,
-                   foo_rel: payload['data']['relationships']['foo'] }
+                   foo_rel: payload['data']['relationships']['foo'],
+                   type: 'foo' }
 
       expect(actual).to eq(expected)
     end
@@ -73,7 +73,7 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
         }
       }
       actual = deserializable_foo.call(payload)
-      expected = {}
+      expected = { type: 'foo' }
 
       expect(actual).to eq(expected)
     end
@@ -87,26 +87,7 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
         }
       }
       actual = deserializable_foo.call(payload)
-      expected = {}
-
-      expect(actual).to eq(expected)
-    end
-  end
-
-  context 'relationship is not to-one' do
-    it 'does not create corresponding fields' do
-      payload = {
-        'data' => {
-          'type' => 'foo',
-          'relationships' => {
-            'foo' => {
-              'data' => []
-            }
-          }
-        }
-      }
-      actual = deserializable_foo.call(payload)
-      expected = {}
+      expected = { type: 'foo' }
 
       expect(actual).to eq(expected)
     end

--- a/spec/resource/DSL/has_one_spec.rb
+++ b/spec/resource/DSL/has_one_spec.rb
@@ -4,9 +4,7 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
   let(:deserializable_foo) do
     Class.new(JSONAPI::Deserializable::Resource) do
       has_one :foo do |rel, id, type|
-        field foo_id: id
-        field foo_type: type
-        field foo_rel: rel
+        Hash[foo_id: id, foo_type: type, foo_rel: rel]
       end
     end
   end
@@ -108,8 +106,8 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
       }
       klass = Class.new(JSONAPI::Deserializable::Resource) do
         has_one do |name, _value, id, type|
-          field "custom_#{name}_id".to_sym => id
-          field "custom_#{name}_type".to_sym => type
+          Hash["custom_#{name}_id".to_sym => id,
+               "custom_#{name}_type".to_sym => type]
         end
       end
       actual = klass.call(payload)

--- a/spec/resource/DSL/has_one_spec.rb
+++ b/spec/resource/DSL/has_one_spec.rb
@@ -11,83 +11,111 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
     end
   end
 
-  context 'relationship is not nil' do
-    let(:payload) do
-      {
-        'data' => {
-          'type' => 'foo',
-          'relationships' => {
-            'foo' => {
-              'data' => { 'type' => 'foo', 'id' => 'bar' }
+  context 'when providing the relationship name' do
+    context 'relationship is not nil' do
+      let(:payload) do
+        {
+          'data' => {
+            'type' => 'foo',
+            'relationships' => {
+              'foo' => {
+                'data' => { 'type' => 'foo', 'id' => 'bar' }
+              }
             }
           }
         }
+      end
+
+      it 'creates corresponding fields' do
+        actual = deserializable_foo.call(payload)
+        expected = { foo_id: 'bar', foo_type: 'foo',
+                     foo_rel: payload['data']['relationships']['foo'],
+                     type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+
+      it 'defaults to creating #{name}_id and #{name}_type' do
+        klass = Class.new(JSONAPI::Deserializable::Resource)
+        actual = klass.call(payload)
+        expected = { foo_id: 'bar', foo_type: 'foo', type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'relationship is nil' do
+      it 'creates corresponding fields' do
+        payload = {
+          'data' => {
+            'type' => 'foo',
+            'relationships' => {
+              'foo' => {
+                'data' => nil
+              }
+            }
+          }
+        }
+        actual = deserializable_foo.call(payload)
+        expected = { foo_id: nil, foo_type: nil,
+                     foo_rel: payload['data']['relationships']['foo'],
+                     type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'relationship is absent' do
+      it 'does not create corresponding fields' do
+        payload = {
+          'data' => {
+            'type' => 'foo',
+            'relationships' => {}
+          }
+        }
+        actual = deserializable_foo.call(payload)
+        expected = { type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+    end
+
+    context 'there is no relationships member' do
+      it 'does not create corresponding fields' do
+        payload = {
+          'data' => {
+            'type' => 'foo'
+          }
+        }
+        actual = deserializable_foo.call(payload)
+        expected = { type: 'foo' }
+
+        expect(actual).to eq(expected)
+      end
+    end
+  end
+
+  context 'when omitting the relationship name' do
+    it 'sets the default has_one relationship deserialization scheme' do
+      payload = {
+        'data' => {
+          'type' => 'foo',
+          'relationships' => {
+            'foo' => { 'data' => { 'type' => 'bar', 'id' => 'baz' } },
+            'bar' => { 'data' => { 'type' => 'foo', 'id' => 'bar' } }
+          }
+        }
       }
-    end
-
-    it 'creates corresponding fields' do
-      actual = deserializable_foo.call(payload)
-      expected = { foo_id: 'bar', foo_type: 'foo',
-                   foo_rel: payload['data']['relationships']['foo'],
-                   type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-
-    it 'defaults to creating #{name}_id and #{name}_type' do
-      klass = Class.new(JSONAPI::Deserializable::Resource)
+      klass = Class.new(JSONAPI::Deserializable::Resource) do
+        has_one do |name, _value, id, type|
+          field "custom_#{name}_id".to_sym => id
+          field "custom_#{name}_type".to_sym => type
+        end
+      end
       actual = klass.call(payload)
-      expected = { foo_id: 'bar', foo_type: 'foo', type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-  end
-
-  context 'relationship is nil' do
-    it 'creates corresponding fields' do
-      payload = {
-        'data' => {
-          'type' => 'foo',
-          'relationships' => {
-            'foo' => {
-              'data' => nil
-            }
-          }
-        }
-      }
-      actual = deserializable_foo.call(payload)
-      expected = { foo_id: nil, foo_type: nil,
-                   foo_rel: payload['data']['relationships']['foo'],
+      expected = { custom_foo_id: 'baz', custom_foo_type: 'bar',
+                   custom_bar_id: 'bar', custom_bar_type: 'foo',
                    type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-  end
-
-  context 'relationship is absent' do
-    it 'does not create corresponding fields' do
-      payload = {
-        'data' => {
-          'type' => 'foo',
-          'relationships' => {}
-        }
-      }
-      actual = deserializable_foo.call(payload)
-      expected = { type: 'foo' }
-
-      expect(actual).to eq(expected)
-    end
-  end
-
-  context 'there is no relationships member' do
-    it 'does not create corresponding fields' do
-      payload = {
-        'data' => {
-          'type' => 'foo'
-        }
-      }
-      actual = deserializable_foo.call(payload)
-      expected = { type: 'foo' }
 
       expect(actual).to eq(expected)
     end

--- a/spec/resource/DSL/has_one_spec.rb
+++ b/spec/resource/DSL/has_one_spec.rb
@@ -103,7 +103,7 @@ describe JSONAPI::Deserializable::Resource, '.has_one' do
       }
     }
     klass = Class.new(JSONAPI::Deserializable::Resource) do
-      def deserialize_has_one(name, _value, id, type)
+      has_one do |name, _value, id, type|
         { "custom_#{name}_id".to_sym => id,
           "custom_#{name}_type".to_sym => type }
       end

--- a/spec/resource/DSL/id_spec.rb
+++ b/spec/resource/DSL/id_spec.rb
@@ -7,7 +7,7 @@ describe JSONAPI::Deserializable::Resource, '.id' do
       id { |i| field id: i }
     end
     actual = klass.call(payload)
-    expected = { id: 'bar' }
+    expected = { id: 'bar', type: 'foo' }
 
     expect(actual).to eq(expected)
   end
@@ -18,18 +18,16 @@ describe JSONAPI::Deserializable::Resource, '.id' do
       id { |i| field id: i }
     end
     actual = klass.call(payload)
-    expected = {}
+    expected = { type: 'foo' }
 
     expect(actual).to eq(expected)
   end
 
   it 'defaults to creating an id field' do
     payload = { 'data' => { 'type' => 'foo', 'id' => 'bar' } }
-    klass = Class.new(JSONAPI::Deserializable::Resource) do
-      id
-    end
+    klass = Class.new(JSONAPI::Deserializable::Resource)
     actual = klass.call(payload)
-    expected = { id: 'bar' }
+    expected = { id: 'bar', type: 'foo' }
 
     expect(actual).to eq(expected)
   end

--- a/spec/resource/DSL/id_spec.rb
+++ b/spec/resource/DSL/id_spec.rb
@@ -4,7 +4,7 @@ describe JSONAPI::Deserializable::Resource, '.id' do
   it 'creates corresponding field if id is present' do
     payload = { 'data' => { 'type' => 'foo', 'id' => 'bar' } }
     klass = Class.new(JSONAPI::Deserializable::Resource) do
-      id { |i| field id: i }
+      id { |i| Hash[id: i] }
     end
     actual = klass.call(payload)
     expected = { id: 'bar', type: 'foo' }
@@ -15,7 +15,7 @@ describe JSONAPI::Deserializable::Resource, '.id' do
   it 'does not create corresponding field if id is absent' do
     payload = { 'data' => { 'type' => 'foo' } }
     klass = Class.new(JSONAPI::Deserializable::Resource) do
-      id { |i| field id: i }
+      id { |i| Hash[id: i] }
     end
     actual = klass.call(payload)
     expected = { type: 'foo' }

--- a/spec/resource/DSL/type_spec.rb
+++ b/spec/resource/DSL/type_spec.rb
@@ -14,9 +14,7 @@ describe JSONAPI::Deserializable::Resource, '.type' do
 
   it 'defaults to creating a type field' do
     payload = { 'data' => { 'type' => 'foo' } }
-    klass = Class.new(JSONAPI::Deserializable::Resource) do
-      type
-    end
+    klass = Class.new(JSONAPI::Deserializable::Resource)
     actual = klass.call(payload)
     expected = { type: 'foo' }
 

--- a/spec/resource/DSL/type_spec.rb
+++ b/spec/resource/DSL/type_spec.rb
@@ -4,7 +4,7 @@ describe JSONAPI::Deserializable::Resource, '.type' do
   it 'creates corresponding field' do
     payload = { 'data' => { 'type' => 'foo' } }
     klass = Class.new(JSONAPI::Deserializable::Resource) do
-      type { |t| field type: t }
+      type { |t| Hash[type: t] }
     end
     actual = klass.call(payload)
     expected = { type: 'foo' }


### PR DESCRIPTION
# TL;DR
Deserialization now deserializes the whole payload (no more whitelisting), with the ability to add custom mappings for specific attributes/relationships (and type/id).

# Longer explanation
This PR changes the way deserialization works. Current situation is: we loop through the explicitly targeted elements (id/type/attributes/relationships), and for each element, if it is present in the payload, we create the corresponding fields.

With this PR, we do the opposite: we loop through the elements of the payload, and for each of those, if there is a custom block, we use it, otherwise we fall back to a default deserialization scheme (depending on whether it is the type/id, an attribute, a has_one relationship, or a has_many relationship).

This "default deserialization scheme for (type|id|attributes|has_one relationships|has_many relationships)" is overridable by overriding the `deserialize_attribute(key, value)`, `deserialize_has_one(key, value, id, type)`, and `deserialize_has_many(key, value, ids, types)` methods.

Closes #5 as this removes whitelisting.