### PR TITLE
Remove jsonapi-parser dependency.

### DIFF
--- a/jsonapi-deserializable.gemspec
+++ b/jsonapi-deserializable.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'lib/**/*']
   spec.require_path  = 'lib'
 
-  spec.add_dependency 'jsonapi-parser', '0.1.1'
-
   spec.add_development_dependency 'rake',    '~> 11.3'
   spec.add_development_dependency 'rspec',   '~> 3.4'
   spec.add_development_dependency 'codecov', '~> 0.1'

--- a/lib/jsonapi/deserializable/relationship.rb
+++ b/lib/jsonapi/deserializable/relationship.rb
@@ -1,5 +1,4 @@
 require 'jsonapi/deserializable/relationship/dsl'
-require 'jsonapi/parser/relationship'
 
 module JSONAPI
   module Deserializable
@@ -21,7 +20,6 @@ module JSONAPI
       end
 
       def initialize(payload)
-        Parser::Relationship.parse!(payload)
         @document = payload
         @data = payload['data']
         deserialize!
@@ -55,7 +53,7 @@ module JSONAPI
 
       def deserialize_has_many
         block = self.class.has_many_block
-        return {} unless block
+        return {} unless block && @data.is_a?(Array)
         ids = @data.map { |ri| ri['id'] }
         types = @data.map { |ri| ri['type'] }
         block.call(@document, ids, types)

--- a/lib/jsonapi/deserializable/resource.rb
+++ b/lib/jsonapi/deserializable/resource.rb
@@ -1,5 +1,4 @@
 require 'jsonapi/deserializable/resource/dsl'
-require 'jsonapi/parser/resource'
 
 module JSONAPI
   module Deserializable
@@ -34,14 +33,14 @@ module JSONAPI
       end
 
       def initialize(payload)
-        Parser::Resource.parse!(payload)
         @document = payload
-        @data = @document['data']
+        @data = @document['data'] || {}
         @type = @data['type']
         @id   = @data['id']
         @attributes    = @data['attributes'] || {}
         @relationships = @data['relationships'] || {}
         deserialize!
+
         freeze
       end
 
@@ -132,7 +131,7 @@ module JSONAPI
       def deserialize_has_many_rel(key, val)
         block = self.class.has_many_rel_blocks[key] ||
                 self.class.default_has_many_rel_block
-        return {} unless block
+        return {} unless block && val['data'].is_a?(Array)
 
         ids   = val['data'].map { |ri| ri['id'] }
         types = val['data'].map { |ri| ri['type'] }

--- a/spec/relationship/has_many_spec.rb
+++ b/spec/relationship/has_many_spec.rb
@@ -49,11 +49,12 @@ describe JSONAPI::Deserializable::Relationship, '.has_many' do
   end
 
   context 'data is absent' do
-    it 'raises InvalidDocument' do
+    it 'creates an empty hash' do
       payload = {}
+      actual = deserializable_foo.call(payload)
+      expected = {}
 
-      expect { deserializable_foo.call(payload) }
-        .to raise_error(JSONAPI::Parser::InvalidDocument)
+      expect(actual).to eq(expected)
     end
   end
 

--- a/spec/relationship/has_one_spec.rb
+++ b/spec/relationship/has_one_spec.rb
@@ -43,11 +43,12 @@ describe JSONAPI::Deserializable::Relationship, '.has_one' do
   end
 
   context 'data is absent' do
-    it 'raises InvalidDocument' do
+    it 'creates corresponding fields' do
       payload = {}
+      actual = deserializable_foo.call(payload)
+      expected = { foo_id: nil, foo_type: nil, foo_rel: payload }
 
-      expect { deserializable_foo.call(payload) }
-        .to raise_error(JSONAPI::Parser::InvalidDocument)
+      expect(actual).to eq(expected)
     end
   end
 


### PR DESCRIPTION
From now on, the deserializer will simply assume somewhat clean data is passed. Downstream libraries might still choose to validate the payload via `jsonapi-parser`.