### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  ruby_rails_test_matrix:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby: [2.6, 2.7, '3.0', 3.1, ruby-head]
+
+    steps:
+    - uses: actions/checkout@master
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # 'bundle install' and cache
+    - name: Runs code QA and tests
+      run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, '3.0', 3.1, ruby-head]
+        ruby: [2.6, 2.7, '3.0', 3.1, 3.2, ruby-head]
 
     steps:
     - uses: actions/checkout@master

--- a/jsonapi-deserializable.gemspec
+++ b/jsonapi-deserializable.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'lib/**/*']
   spec.require_path  = 'lib'
 
-  spec.add_development_dependency 'rake',    '~> 11.3'
-  spec.add_development_dependency 'rspec',   '~> 3.4'
-  spec.add_development_dependency 'codecov', '~> 0.1'
+  spec.add_development_dependency 'rake',      '>= 11.3'
+  spec.add_development_dependency 'rspec',     '~> 3.4'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,4 @@
 require 'simplecov'
 SimpleCov.start
 
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
-
 require 'jsonapi/deserializable'


### PR DESCRIPTION
This PR moves CI to GitHub Actions.

It also removes the now officially sunset [codecov gem](https://github.com/codecov/codecov-ruby).  